### PR TITLE
Add dedicated MEF3 page (mef3io / mef3io-server; deprecate mef_tools)

### DIFF
--- a/source/main_page/index.rst
+++ b/source/main_page/index.rst
@@ -10,6 +10,7 @@
    :caption: Projects:
    :hidden:
 
+   MEF3 tools <mef3>
    Papers with Code <bnel_projects/index.html>
 
 BrainMaze toolbox |logo_brainmaze|
@@ -42,16 +43,32 @@ package with its own documentation.
 
       ZeroMQ communication wrappers for real-time acquisition pipelines.
 
-Other tools
-===========
+MEF3 tools
+==========
+
+Open Python and gRPC toolchain for the Multiscale Electrophysiology Format
+(MEF3). See the :doc:`MEF3 tools <mef3>` page for details, including the
+deprecated ``mef_tools`` library.
 
 .. grid:: 1 2 2 2
    :gutter: 2
 
-   .. grid-item-card:: MEF Tools
-      :link: https://github.com/bnelair/mef_tools
+   .. grid-item-card:: mef3io
+      :link: https://bnelair.github.io/mef3io/
 
-      Reading and writing Multiscale Electrophysiology Format (MEF3) files.
+      Read and write MEF3 data in Python. Replaces ``mef_tools``.
+
+   .. grid-item-card:: mef3io-server
+      :link: https://bnelair.github.io/mef3io-server/
+
+      gRPC streaming server with pre-caching for viewers and data-processing
+      applications.
+
+More
+====
+
+.. grid:: 1 2 2 2
+   :gutter: 2
 
    .. grid-item-card:: Papers with Code 🔬
       :link: bnel_projects/index.html

--- a/source/main_page/mef3.rst
+++ b/source/main_page/mef3.rst
@@ -1,0 +1,71 @@
+.. _mef3:
+
+MEF3 tools
+==========
+
+The **Multiscale Electrophysiology Format (MEF3)** is a compressed, encrypted
+file format designed for large-scale, long-term electrophysiology recordings.
+BNEL develops and maintains an open Python and gRPC toolchain for working with
+MEF3 data, from low-level reading and writing to high-throughput streaming for
+viewers and data-processing applications.
+
+.. grid:: 1 2 2 2
+   :gutter: 2
+
+   .. grid-item-card:: mef3io
+      :link: https://bnelair.github.io/mef3io/
+
+      The current library for reading and writing MEF3 data in Python.
+      **Replaces mef_tools.**
+
+   .. grid-item-card:: mef3io-server
+      :link: https://bnelair.github.io/mef3io-server/
+
+      A gRPC server for efficient, concurrent streaming of MEF3 data, with
+      pre-caching for viewers and data-processing applications.
+
+mef3io
+------
+
+``mef3io`` is the recommended library for reading and writing MEF3 data in
+Python. It is the successor to ``mef_tools`` and the starting point for new
+projects that work with MEF3 files.
+
+- **Documentation**: https://bnelair.github.io/mef3io/
+- **Repository**: https://github.com/bnelair/mef3io
+
+mef3io-server
+-------------
+
+``mef3io-server`` is a gRPC server for efficient, concurrent streaming of MEF3
+electrophysiology data. It is aimed at scenarios that need fast, repeated access
+to large recordings, in particular:
+
+- **pre-caching in viewers**, so that scrolling and paging through long
+  recordings stays responsive, and
+- **data-processing applications**, where many workers stream overlapping
+  segments concurrently.
+
+- **Documentation**: https://bnelair.github.io/mef3io-server/
+- **Repository**: https://github.com/bnelair/mef3io-server
+
+Deprecated and legacy
+---------------------
+
+.. warning::
+
+   ``mef_tools`` is **deprecated** and kept as an archive for legacy support
+   only. It is no longer actively developed. New projects should use
+   `mef3io`_ (and `mef3io-server`_ where streaming is needed) instead.
+
+``mef_tools`` was the original high-level BNEL library for reading and writing
+MEF3 files. It builds on the upstream ``pymef``/``meflib`` stack. Existing code
+that depends on it will continue to work, but it will not receive new features.
+The components below are listed for legacy context:
+
+- **mef_tools** (archived) — high-level read/write library, BNEL:
+  https://github.com/bnelair/mef_tools
+- **pymef** — Python wrapper for the MEF library, upstream (msel-source):
+  https://github.com/msel-source/pymef
+- **meflib** — the underlying MEF C library, upstream (msel-source):
+  https://github.com/msel-source/meflib


### PR DESCRIPTION
Adds a dedicated **MEF3 tools** page and elevates MEF3 from an 'Other tools' card to its own landing section.

## Content
- **mef3io** — current library for reading/writing MEF3 in Python; **replaces `mef_tools`**. Links to its docs (bnelair.github.io/mef3io/) + repo.
- **mef3io-server** — gRPC server for concurrent MEF3 streaming, with **pre-caching for viewers and data-processing apps**. Links to docs (bnelair.github.io/mef3io-server/) + repo.
- **Deprecated / legacy** section: `mef_tools` (archived, BNEL) kept for legacy support only, plus the upstream **pymef** and **meflib** (msel-source) for legacy context.

Sphinx-only build (no installs); verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)